### PR TITLE
Resolve model configuration mismatch for causal LM

### DIFF
--- a/colab_model_fix.py
+++ b/colab_model_fix.py
@@ -1,0 +1,81 @@
+# Quick fix for your Colab notebook
+# Copy and paste this code to replace your current model loading code
+
+from transformers import AutoConfig, AutoTokenizer, AutoModel
+from huggingface_hub import login
+
+# Your existing token and model_name variables
+token = "your_token_here"  # Replace with your actual token
+model_name = "your_model_name_here"  # Replace with your actual model name
+
+# Login to HuggingFace
+login(token=token)
+
+# First, check what type of model this is
+print("Checking model configuration...")
+try:
+    config = AutoConfig.from_pretrained(model_name, token=token, trust_remote_code=True)
+    print(f"Model type: {config.__class__.__name__}")
+    print(f"Model architecture: {getattr(config, 'model_type', 'Unknown')}")
+    
+    # Load tokenizer (this should work regardless of model type)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, token=token, trust_remote_code=True)
+    print("✓ Tokenizer loaded successfully")
+    
+    # The issue: NAT models are for computer vision, not causal language modeling
+    if "Nat" in config.__class__.__name__:
+        print("⚠ This appears to be a NAT (Neighborhood Attention Transformer) model.")
+        print("NAT models are designed for computer vision tasks, not text generation.")
+        print("\nTrying to load as vision model...")
+        
+        try:
+            from transformers import AutoModelForImageClassification
+            model = AutoModelForImageClassification.from_pretrained(
+                model_name, 
+                token=token, 
+                trust_remote_code=True
+            )
+            print("✓ Model loaded successfully as AutoModelForImageClassification")
+        except:
+            # Fallback to generic AutoModel
+            model = AutoModel.from_pretrained(
+                model_name, 
+                token=token, 
+                trust_remote_code=True
+            )
+            print("✓ Model loaded successfully as AutoModel")
+    
+    else:
+        # Try different auto classes based on the model type
+        try:
+            from transformers import AutoModelForCausalLM
+            model = AutoModelForCausalLM.from_pretrained(
+                model_name, 
+                token=token, 
+                trust_remote_code=True
+            )
+            print("✓ Model loaded successfully as AutoModelForCausalLM")
+        except ValueError:
+            try:
+                from transformers import AutoModelForMaskedLM
+                model = AutoModelForMaskedLM.from_pretrained(
+                    model_name, 
+                    token=token, 
+                    trust_remote_code=True
+                )
+                print("✓ Model loaded successfully as AutoModelForMaskedLM")
+            except ValueError:
+                # Fallback to generic AutoModel
+                model = AutoModel.from_pretrained(
+                    model_name, 
+                    token=token, 
+                    trust_remote_code=True
+                )
+                print("✓ Model loaded successfully as AutoModel")
+
+except Exception as e:
+    print(f"Error: {e}")
+    print("\nIf the model name is correct, this might be a custom model.")
+    print("Please share the model name so I can provide more specific guidance.")
+
+# Now you have 'model' and 'tokenizer' loaded correctly

--- a/fix_model_loading.py
+++ b/fix_model_loading.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Script to help diagnose and fix model loading issues with transformers library.
+This addresses the ValueError when trying to load a model with incompatible configuration.
+"""
+
+from transformers import AutoConfig, AutoTokenizer, AutoModel
+from transformers.models.auto.auto_factory import _get_model_class
+import warnings
+
+def diagnose_model(model_name_or_path, token=None):
+    """
+    Diagnose what type of model this is and suggest the correct loading method.
+    
+    Args:
+        model_name_or_path (str): Model name or path
+        token (str, optional): HuggingFace token for authentication
+    """
+    print(f"Diagnosing model: {model_name_or_path}")
+    print("-" * 50)
+    
+    try:
+        # Load the configuration first to understand the model type
+        config = AutoConfig.from_pretrained(model_name_or_path, token=token, trust_remote_code=True)
+        print(f"✓ Model configuration loaded successfully")
+        print(f"  Configuration class: {config.__class__.__name__}")
+        print(f"  Model type: {getattr(config, 'model_type', 'Unknown')}")
+        
+        # Check what auto classes support this config
+        from transformers import (
+            AutoModelForCausalLM, 
+            AutoModelForMaskedLM, 
+            AutoModelForSequenceClassification,
+            AutoModelForImageClassification,
+            AutoModelForObjectDetection,
+            AutoModel
+        )
+        
+        auto_classes = [
+            ("AutoModelForCausalLM", AutoModelForCausalLM),
+            ("AutoModelForMaskedLM", AutoModelForMaskedLM), 
+            ("AutoModelForSequenceClassification", AutoModelForSequenceClassification),
+            ("AutoModelForImageClassification", AutoModelForImageClassification),
+            ("AutoModelForObjectDetection", AutoModelForObjectDetection),
+            ("AutoModel", AutoModel),
+        ]
+        
+        supported_classes = []
+        for class_name, auto_class in auto_classes:
+            try:
+                if config.__class__ in auto_class._model_mapping.keys():
+                    supported_classes.append(class_name)
+            except AttributeError:
+                continue
+        
+        if supported_classes:
+            print(f"✓ Supported Auto classes: {', '.join(supported_classes)}")
+        else:
+            print("⚠ No standard Auto classes support this configuration")
+            print("  This might be a custom model that requires special handling")
+        
+        return config, supported_classes
+        
+    except Exception as e:
+        print(f"✗ Error loading configuration: {e}")
+        return None, []
+
+def load_model_correctly(model_name_or_path, token=None):
+    """
+    Attempt to load the model using the correct Auto class.
+    
+    Args:
+        model_name_or_path (str): Model name or path
+        token (str, optional): HuggingFace token for authentication
+    """
+    config, supported_classes = diagnose_model(model_name_or_path, token)
+    
+    if not config or not supported_classes:
+        print("❌ Cannot determine how to load this model")
+        return None, None
+    
+    print(f"\nAttempting to load model with {supported_classes[0]}...")
+    
+    try:
+        # Load tokenizer
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_name_or_path, 
+            token=token, 
+            trust_remote_code=True
+        )
+        print("✓ Tokenizer loaded successfully")
+        
+        # Load model with the first supported auto class
+        if "AutoModelForCausalLM" in supported_classes:
+            from transformers import AutoModelForCausalLM
+            model = AutoModelForCausalLM.from_pretrained(
+                model_name_or_path, 
+                token=token, 
+                trust_remote_code=True
+            )
+        elif "AutoModelForMaskedLM" in supported_classes:
+            from transformers import AutoModelForMaskedLM
+            model = AutoModelForMaskedLM.from_pretrained(
+                model_name_or_path, 
+                token=token, 
+                trust_remote_code=True
+            )
+        elif "AutoModel" in supported_classes:
+            model = AutoModel.from_pretrained(
+                model_name_or_path, 
+                token=token, 
+                trust_remote_code=True
+            )
+        else:
+            # Try with the first supported class
+            class_name = supported_classes[0]
+            print(f"Using {class_name} for loading...")
+            exec(f"from transformers import {class_name}")
+            model_class = eval(class_name)
+            model = model_class.from_pretrained(
+                model_name_or_path, 
+                token=token, 
+                trust_remote_code=True
+            )
+        
+        print("✓ Model loaded successfully")
+        return model, tokenizer
+        
+    except Exception as e:
+        print(f"✗ Error loading model: {e}")
+        return None, None
+
+def alternative_loading_methods(model_name_or_path, token=None):
+    """
+    Show alternative loading methods if standard Auto classes fail.
+    """
+    print("\nAlternative loading methods:")
+    print("-" * 30)
+    
+    # Method 1: Direct model loading with trust_remote_code
+    print("1. If this is a custom model, try loading with trust_remote_code=True:")
+    print(f"""
+from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+config = AutoConfig.from_pretrained("{model_name_or_path}", trust_remote_code=True)
+tokenizer = AutoTokenizer.from_pretrained("{model_name_or_path}", trust_remote_code=True)
+model = AutoModel.from_pretrained("{model_name_or_path}", trust_remote_code=True)
+""")
+    
+    # Method 2: Check if it's a vision model
+    print("2. If this is a vision model (NAT = Neighborhood Attention Transformer):")
+    print(f"""
+# NAT models are typically for computer vision, not text generation
+from transformers import AutoImageProcessor, AutoModelForImageClassification
+
+processor = AutoImageProcessor.from_pretrained("{model_name_or_path}")
+model = AutoModelForImageClassification.from_pretrained("{model_name_or_path}")
+""")
+    
+    # Method 3: Manual class loading
+    print("3. If you know the specific model class:")
+    print(f"""
+# Replace 'SpecificModelClass' with the actual class name
+from transformers import SpecificModelClass, AutoTokenizer
+
+model = SpecificModelClass.from_pretrained("{model_name_or_path}")
+tokenizer = AutoTokenizer.from_pretrained("{model_name_or_path}")
+""")
+
+if __name__ == "__main__":
+    # Example usage - replace with your actual model name
+    # model_name = "your_model_name_here"
+    # token = "your_hf_token_here"  # Optional
+    
+    print("Model Loading Diagnostics Tool")
+    print("=" * 50)
+    print("This script helps diagnose and fix model loading issues.")
+    print("\nTo use this script:")
+    print("1. Replace 'your_model_name_here' with your actual model name")
+    print("2. Optionally provide your HuggingFace token")
+    print("3. Run the diagnostic functions")
+    
+    # Uncomment and modify these lines to test with your model:
+    # model, tokenizer = load_model_correctly(model_name, token)
+    # if model is None:
+    #     alternative_loading_methods(model_name, token)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add scripts to correctly load HuggingFace models by detecting their configuration type, resolving `ValueError` when vision models are loaded as causal LMs.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `ValueError` occurs when a user attempts to load a model with a `NatConfig` (Neighborhood Attention Transformer), which is a computer vision model, using `AutoModelForCausalLM`, which is designed for text generation. The added scripts diagnose the model's configuration and suggest/implement loading with the appropriate `AutoModel` class (e.g., `AutoModelForImageClassification` or `AutoModel`) to prevent this incompatibility error.

---
<a href="https://cursor.com/background-agent?bcId=bc-61a931fb-216b-4895-8b9f-bd6413582978">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61a931fb-216b-4895-8b9f-bd6413582978">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>